### PR TITLE
[add] apiの認証用Middlewareの追加。

### DIFF
--- a/app/Http/Middleware/OnceAuth.php
+++ b/app/Http/Middleware/OnceAuth.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class OnceAuth
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        Auth::once(["account" => $request->input("account"),"password" => $request->input("password")]);
+        return $next($request);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Http\Request;
-
+use App\Http\Middleware\OnceAuth;
 /*
 |--------------------------------------------------------------------------
 | API Routes
@@ -19,4 +19,9 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
 Route::prefix('v1')->group(function() {
     Route::get('/users', 'UserController@index');
+
+    //TODO:認証が必要なAPIの例 何か変わりに書いたら削除して
+    Route::middleware(OnceAuth::class)->post('/authuser', function(Request $request){
+        return json_encode(Auth::user());
+    });
 });


### PR DESCRIPTION
OnceAuthミドルウェアはrequestのパラメータとして

・accountをキーとしてaccount
・passwordをキーとしてpassword

を渡してもらえればそのリクエスト間だけ認証します