### PR TITLE
[add] イベントと結びつけるためのセレクタを生成するselectorメソッドを追加

### DIFF
--- a/public/js/util/selector.js
+++ b/public/js/util/selector.js
@@ -1,0 +1,1 @@
+const selector = (elementName,eventName) => `[data-siori-${elementName}="${eventName}"]`;

--- a/resources/views/layouts/template.blade.php
+++ b/resources/views/layouts/template.blade.php
@@ -13,6 +13,7 @@
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="{{ asset('js/jquery.tagsinput.js') }}"></script>
+    <script type="text/javascript" src="{{ asset('js/util/selector.js') }}"></script>
      <!-- Styles -->
     <link href="{{ asset('css/default.css') }}" rel="stylesheet">
     <link href="{{ asset('css/hamburger.css') }}" rel="stylesheet">


### PR DESCRIPTION
今後イベントと結びつけるための識別子として data-siori-[エレメント名] という任意属性を用います。
そして、値でそのイベントで行う処理の名前をもたせます。

例：送信ボタン
data-siori-button="send"

そのエレメントに対してのセレクタを書くのがめんどくさいので、
セレクタを生成するメソッド"selector"を追加しました。