### PR TITLE
[delete] package-lock.jsonを追跡対象外に

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Homestead.yaml
 npm-debug.log
 .laradock
 .DS_Store
+
+# npm
+package-lock.json


### PR DESCRIPTION
package-lock.jsonはnpm ver 5以上で生成されるっぽいです