### PR TITLE
[fix,add] API認証方法を独自Tokenに変更、お気に入りの表示作成削除処理の追加

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -25,7 +25,7 @@ class LoginController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/';
+    protected $redirectTo = '/logined';
 
     /**
      * Create a new controller instance.

--- a/app/Http/Controllers/FavoriteController.php
+++ b/app/Http/Controllers/FavoriteController.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\SioriFriends\Models\Book\BookRepository;
+use Illuminate\Support\Facades\Auth;
+
+
+class FavoriteController extends Controller
+{
+    /**
+     * Create a new controller instance.
+     *
+     */
+    public function __construct(BookRepository $books)
+    {
+        $this->books = $books;
+    }
+
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     * @param  Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function create(Request $request)
+    {
+        $book = $this->books->findById($request["bookId"]);
+
+        if ($book->isFavorite(Auth::user()))
+            return json_encode(['message' => 'already favorited']);
+
+        Auth::user()->addFavorite($book);
+        return json_encode(['message' => 'create favorite success']);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  uuid  $account
+     * @return \Illuminate\Http\Response
+     */
+    public function show($account)
+    {
+        try {
+            $tmpBooks = $this->books->findFavoritesByUserAccount($account);
+            $books = [];
+            foreach($tmpBooks as $book){
+                $books[] = [
+                    'id' => $book->id,
+                    'title' => $book->title,
+                    'isFavorite' => Auth::check() && $book->isFavorite(Auth::user())
+                ];
+            }
+            return view('bookshelf',['books' => $books]);
+        } catch (ModelNotFoundException $exception) {
+            abort(404, 'User not found.');
+        }
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Request $request)
+    {
+        $book = $this->books->findById($request["bookId"]);
+
+        if (false == $book->isFavorite(Auth::user()))
+            return json_encode(['message' => 'already unfavorited']);
+
+        Auth::user()->removeFavorite($book);
+
+        return json_encode(['message' => 'unfavorite success']);
+    }
+}

--- a/app/Http/Middleware/OnceAuth.php
+++ b/app/Http/Middleware/OnceAuth.php
@@ -4,6 +4,10 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Support\Facades\Auth;
+use App\SioriFriends\Models\Api\ApiToken;
+use App\SioriFriends\Models\User\User;
+
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class OnceAuth
 {
@@ -16,7 +20,13 @@ class OnceAuth
      */
     public function handle($request, Closure $next)
     {
-        Auth::once(["account" => $request->input("account"),"password" => $request->input("password")]);
-        return $next($request);
+        try{
+            $apiToken = ApiToken::where("token",$request->input("token"))->firstOrFail();
+            Auth::login(User::where(["id" => $apiToken->user_id])->firstOrFail());
+            return $next($request);
+        } catch(ModelNotFoundException $e) {
+            return response()->json(["error" => "Forbidden"],403);
+        }
+
     }
 }

--- a/app/SioriFriends/Models/Api/ApiApplication.php
+++ b/app/SioriFriends/Models/Api/ApiApplication.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\SioriFriends\Models\Api;
+
+use Illuminate\Database\Eloquent\Model;
+use Alsofronie\Uuid\Uuid32ModelTrait;
+
+class ApiApplication extends Model
+{
+    use Uuid32ModelTrait;
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    protected $fillable = [
+        'name','description','url'
+    ];
+}

--- a/app/SioriFriends/Models/Api/ApiToken.php
+++ b/app/SioriFriends/Models/Api/ApiToken.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\SioriFriends\Models\Api;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ApiToken extends Model
+{
+    protected $fillable = [
+        'token','expire'
+    ];
+}

--- a/app/SioriFriends/Models/Book/BookRepository.php
+++ b/app/SioriFriends/Models/Book/BookRepository.php
@@ -19,6 +19,8 @@ interface BookRepository
 
     public function findByUserAccount(string $account);
 
+    public function findFavoritesByUserAccount(string $account);
+
     public function fetchNewBooks(int $limit);
 
     public function add(Book $book);

--- a/app/SioriFriends/Models/User/User.php
+++ b/app/SioriFriends/Models/User/User.php
@@ -2,6 +2,7 @@
 
 namespace App\SioriFriends\Models\User;
 
+use App\SioriFriends\Models\Api\ApiToken;
 use App\SioriFriends\Models\Book\Book;
 use App\SioriFriends\Models\User\Follow;
 use Carbon\Carbon;
@@ -165,4 +166,26 @@ class User extends Authenticatable
             ->where('id', $user->id)
             ->exists();
     }
+
+    /**
+     * 栞フレンズ内で使用するAPITokenを返す
+     */
+    public function localToken(){
+        $apiToken = ApiToken::where('user_id',Auth::user()->account)->where('application_id','0000000000siorifriends0000000000');
+
+        if ($apiToken->exists()){
+            return $apiToken->first();
+        }else{
+            $apiToken = new ApiToken();
+            $apiToken->user_id = Auth::id();
+            $apiToken->application_id = '0000000000siorifriends0000000000';
+            $apiToken->token = hash('sha256',(Auth::user()->account).'0000000000siorifriends0000000000');
+            $apiToken->expire = date("Y-m-d H:i:s",time() + (14 * 24 * 60 * 60));
+
+            $apiToken->save();
+
+            return $apiToken;
+        }
+    }
+
 }

--- a/app/SioriFriends/Repositories/EloquentBookRepository.php
+++ b/app/SioriFriends/Repositories/EloquentBookRepository.php
@@ -71,6 +71,19 @@ class EloquentBookRepository implements BookRepository
     }
 
     /**
+     * ユーザのアカウント名からそのユーザがお気に入りに登録している本の一覧を取得する。
+     *
+     * @param string $account
+     * @return mixed
+     * @throws ModelNotFoundException ユーザが見つからなかった場合。
+     */
+    public function findFavoritesByUserAccount(string $account)
+    {
+        $user = $this->users->findByAccount($account);
+        return $user->favorites;
+    }
+
+    /**
      *
      * 新着の本を limit 件取得する。
      *

--- a/database/factories/ApiApplicationFactory.php
+++ b/database/factories/ApiApplicationFactory.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: as-is-prog
+ * Date: 17/12/04
+ * Time: 19:25
+ */
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+$factory->define(App\SioriFriends\Models\Api\ApiApplication::class, function (Faker\Generator $faker) {
+    // 生成した uuid から, '-' を除去する。
+    $uuid = preg_replace('/-/', '', $faker->unique()->uuid);
+
+    return [
+        'id' => $uuid,
+        'name' => $faker->sentence,
+        'user_id' => function() {
+            return factory(\App\SioriFriends\Models\User\User::class)->create()->id;
+        },
+        'description' => $faker->text,
+        'url' => $faker->url,
+    ];
+});

--- a/database/migrations/2017_12_04_134542_create_api_applications_table.php
+++ b/database/migrations/2017_12_04_134542_create_api_applications_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateApiApplicationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('api_applications', function (Blueprint $table) {
+            $table->char('id', 32)->primary();
+            $table->string('name');
+            $table->char('user_id',32);
+            $table->string('description');
+            $table->string('url');
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('api_applications');
+    }
+}

--- a/database/migrations/2017_12_04_140629_create_api_tokens_table.php
+++ b/database/migrations/2017_12_04_140629_create_api_tokens_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateApiTokensTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('api_tokens', function (Blueprint $table) {
+            $table->char('user_id',32);
+            $table->char('application_id',32);
+            $table->string('token');
+            $table->timestamp('expire');
+            $table->timestamps();
+
+            $table->primary(['user_id', 'application_id']);
+            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreign('application_id')->references('id')->on('api_applications');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('api_tokens');
+    }
+}

--- a/database/seeds/ApiApplicationSeeder.php
+++ b/database/seeds/ApiApplicationSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\SioriFriends\Models\Book\Book;
+use App\SioriFriends\Models\Book\Anchor;
+
+class ApiApplicationSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+
+    }
+}

--- a/database/seeds/ApiApplicationSeeder.php
+++ b/database/seeds/ApiApplicationSeeder.php
@@ -1,8 +1,8 @@
 <?php
 
 use Illuminate\Database\Seeder;
-use App\SioriFriends\Models\Book\Book;
-use App\SioriFriends\Models\Book\Anchor;
+use App\SioriFriends\Models\Api\ApiApplication;
+use App\SioriFriends\Models\User\User;
 
 class ApiApplicationSeeder extends Seeder
 {
@@ -13,6 +13,19 @@ class ApiApplicationSeeder extends Seeder
      */
     public function run()
     {
+        $sioriFriendsSystem = factory(User::class)->create([
+            'account'   => bcrypt('SioriFriends'),
+            'name'      => 'SioriFriends',
+            'email'     => 'system@siorifriends.net',
+            'password'  => bcrypt(hash('sha256','SioriFriends')),
+        ]);
 
+        $sioriFriendsApp = factory(ApiApplication::class)->create([
+            'id'        => '0000000000siorifriends0000000000',
+            'name'      => 'Siori Friends',
+            'user_id'     => $sioriFriendsSystem->id,
+            'description'  => 'siori friends system',
+            'url' => 'http://localhost/'
+        ]);
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
         if (App::environment('local')) {
             echo 'env local' . PHP_EOL;
             $this->call(LocalSeeder::class);
+            $this->call(ApiApplicationSeeder::class);
         } else if (App::environment('production')) {
             echo 'env production' . PHP_EOL;
         $this->call(UsersTableSeeder::class);
@@ -24,6 +25,7 @@ class DatabaseSeeder extends Seeder
         $this->call(BooksTableSeeder::class);
         $this->call(AnchorsTableSeeder::class);
         $this->call(CommentsTableSeeder::class);
+
         }
     }
 }

--- a/public/js/components/behavior/book.js
+++ b/public/js/components/behavior/book.js
@@ -1,0 +1,48 @@
+/***
+ * bookコンポーネントの振る舞いを記述するファイルです
+ * */
+
+/***
+ * お気に入りボタン
+ */
+$(SioriSelector.componentSelectorGenerate("book")).find(SioriSelector.eventTriggerSelectorGenerate("button","favorite")).on("click",function(){
+
+    const favoriteButton = $(this);
+
+    const bookId = $(this).closest(SioriSelector.componentSelectorGenerate("book")).find(".bookid").text();
+
+    var ajaxData = {
+        type : 'post',
+        data : JSON.stringify({"bookId":bookId,"token":localStorage.getItem("token")}),
+        contentType: 'application/json',
+        dataType : 'json',
+        scriptCharset: 'utf-8',
+        error : function(data) {
+            // Error
+            alert("error");
+//            console.log(data);
+//            $("html").html(data.responseText);
+        }
+    };
+
+    if($(this).hasClass("glyphicon-star")){
+        ajaxData.url = "/api/v1/favorites/destroy";
+
+        ajaxData.success = function(data){
+            console.log(data);
+            favoriteButton.removeClass("glyphicon-star");
+            favoriteButton.addClass("glyphicon-star-empty");
+        };
+
+    }else if($(this).hasClass("glyphicon-star-empty")){
+        ajaxData.url = "/api/v1/favorites/create";
+
+        ajaxData.success = function(data){
+            console.log(data);
+            favoriteButton.removeClass("glyphicon-star-empty");
+            favoriteButton.addClass("glyphicon-star");
+        };
+    }
+
+    $.ajax(ajaxData);
+});

--- a/public/js/util/selector.js
+++ b/public/js/util/selector.js
@@ -1,1 +1,4 @@
-const selector = (elementName,eventName) => `[data-siori-${elementName}="${eventName}"]`;
+const SioriSelector = {
+    "eventTriggerSelectorGenerate": function(elementName,eventName){ return `[data-siori-${elementName}="${eventName}"]`},
+    "componentSelectorGenerate": function(componentName){ return `[data-siori-component="${componentName}"]`}
+};

--- a/resources/views/bookshelf.blade.php
+++ b/resources/views/bookshelf.blade.php
@@ -46,3 +46,7 @@
             });
         </script>
 @endsection
+
+@section('resources')
+    <script src="{{asset("js/components/behavior/book.js")}}"></script>
+@endsection

--- a/resources/views/components/book.blade.php
+++ b/resources/views/components/book.blade.php
@@ -1,4 +1,4 @@
-<div class="col-xs-3 obj">
+<div data-siori-component="book" class="col-xs-3 obj">
     <div class="col-xs-12">
         <div class="book_shadow">
             <div class="book">
@@ -14,9 +14,9 @@
         <div class="userback">
             <div class="is_favo">
             @if($isFavorite)
-                <span class="glyphicon glyphicon-star bookuserID"></span>
+                <span data-siori-button="favorite" class="glyphicon glyphicon-star bookuserID"></span>
             @else
-                <span class="glyphicon glyphicon-star-empty bookuserID"></span>   
+                <span data-siori-button="favorite" class="glyphicon glyphicon-star-empty bookuserID"></span>
             @endif
             </div>
         </div>

--- a/resources/views/layouts/template.blade.php
+++ b/resources/views/layouts/template.blade.php
@@ -92,6 +92,7 @@
     <link rel="stylesheet" href="{{ asset('css/hamburger.css') }}">
     <link rel="stylesheet" href="{{ asset('css/jquery.tagsinput.css') }}">
 
+    <script src="{{ asset('js/util/selector.js') }}"></script>
     <script src="{{ asset('js/jquery.tagsinput.js') }}"></script>
     <script src="{{ asset('js/drawr.js') }}"></script>
     <script src="{{ asset('js/moretext.js') }}"></script>

--- a/resources/views/logined.blade.php
+++ b/resources/views/logined.blade.php
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja">
+<head>
+    <title>Redirect...</title>
+    <script>
+        localStorage.setItem("token","{{Auth::user()->localToken()->token}}");
+        location.href = "/";
+    </script>
+</head>
+<body>
+
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,8 +20,10 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 Route::prefix('v1')->group(function() {
     Route::get('/users', 'UserController@index');
 
-    //TODO:認証が必要なAPIの例 何か変わりに書いたら削除して
-    Route::middleware(OnceAuth::class)->post('/authuser', function(Request $request){
-        return json_encode(Auth::user());
+    Route::middleware(OnceAuth::class)->prefix('/favorites')->group(function(){
+        Route::post('/create', 'FavoriteController@create');
+
+        Route::post('/destroy','FavoriteController@destroy');
     });
+
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,10 +32,7 @@ Route::prefix('/users/{account}')->group(function() {
     Route::get('/follows','User\FollowController');
     Route::get('/followers','User\FollowerController');
     Route::get('/bookshelf','User\BookShelfController@index')->name('bookshelf');
-
-    Route::get('/favorite',function(){
-        return view('favorite');
-    });
+    Route::get('/favorite','FavoriteController@show')->name('favorite');
 });
 
 
@@ -61,4 +58,8 @@ Route::get('/privacy',function(){
 
 Route::get('/help',function(){
     return view('help');
+});
+
+Route::get('/logined',function(){
+    return view('logined');
 });


### PR DESCRIPTION
# できるようになったこと
- /users/{account}/favorite でそのユーザのお気に入りの本を見ることができるぞ！
- /api/v1/favorites/create にpostで認証トークンと本のIDを送りつけるとその本をお気に入りにできるぞ！
- /api/v1/favorites/destroy にpostで認証トークンと本のIDを送りつけるとその本をお気に入り解除できるぞ！
- 本コンポーネントのお気に入りボタンで上記のAPIを叩いて本のお気に入り登録、解除が切り替えられるぞ！

# 知っておいてほしいこと
APIの認証トークンはログイン時にlocalStorageにkey 'token'で保存されます。
localStorage.getItem('token')で取り出せます。
誰かもう少しスマートな実装方法教えてください

トークンの生成方法がなかなかに雑で、
トークンの素がソース内に記載されててやばいのでまた変えます、
具体的には.env辺りに記述？

# TODO
認証トークンの期限切れの確認はまだしてません