### PR TITLE
[add] 検索ページと他のページの結合部分の実装

### DIFF
--- a/app/SioriFriends/Repositories/EloquentBookRepository.php
+++ b/app/SioriFriends/Repositories/EloquentBookRepository.php
@@ -138,7 +138,8 @@ class EloquentBookRepository implements BookRepository
                 "isFirst" => ($page <= 1),
                 "isLast" => $tmpBooks->hasMorePages() == false,
                 "tagSearch" => false,
-                "orderby" => $orderBy
+                "orderby" => $orderBy,
+                "key" => $word
         ]);
     }
 
@@ -166,7 +167,8 @@ class EloquentBookRepository implements BookRepository
             "isFirst" => ($page <= 1),
             "isLast" => $tmpBooks->hasMorePages() == false,
             "tagSearch" => true,
-            "orderby" => $orderBy
+            "orderby" => $orderBy,
+            "key" => $tag
         ]);
     }
 

--- a/resources/views/books/search.blade.php
+++ b/resources/views/books/search.blade.php
@@ -15,7 +15,7 @@
             <form action="{{ route("search") }}" method="get">
                 <div class="col-xs-12 lines-empty">
                     <div class="input-group">
-                            <input type="text" class="form-control" data-siori-textbox="searchkey" name="word" placeholder="検索検索ぅ">
+                            <input type="text" class="form-control" data-siori-textbox="searchkey" name="word" placeholder="検索検索ぅ" value="{{$key}}">
                             <span class="input-group-btn">
                                 <span class="glyphicon glyphicon-search"></span>
                                 <button class="btn btn-default" type="submit">検索</button>

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -79,8 +79,7 @@
         <div class="col-xs-12">
             <p class="h4">
                 @foreach($book->tags as $tag)
-                    {{-- TODO:tagをクリックしたら、そのtagがついた本の一覧を表示する --}}
-                    <span class="label label-default">{{ $tag->name }}</span>
+                    <span class="label label-default" onclick="location.href='{{route("search")."?tag="}}{{$tag->name}}'">{{ $tag->name }}</span>
                 @endforeach
             </p>
         </div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -30,7 +30,7 @@
                     @endcomponent
                 @endforeach
             </div>
-            <a href="#" class="col-xs-5 col-xs-offset-7">→もっと見る</a>
+            <a href="{{route("search")."?orderby=create_desc"}}" class="col-xs-5 col-xs-offset-7">→もっと見る</a>
             <!-- 人気ランキング -->
             <div class="col-xs-12 ranking-list">
                 <div class="text-center" style="border: 1px solid black">人気</div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -4,15 +4,17 @@
     <div class="row">
         <div class="col-xs-10 col-xs-offset-1">
             <!-- 検索フォーム -->
-            <div class="col-xs-12 lines-empty">
-                <div class="input-group">
-                    <input type="text" class="form-control" placeholder="検索検索ぅ">
-                    <span class="input-group-btn">
-                        <span class="glyphicon glyphicon-search"></span>
-                        <button class="btn btn-default" type="submit">検索</button>
-                    </span>
+            <form action="{{ route("search") }}" method="get">
+                <div class="col-xs-12 lines-empty">
+                    <div class="input-group">
+                        <input type="text" class="form-control" name="word" placeholder="検索検索ぅ">
+                        <span class="input-group-btn">
+                            <span class="glyphicon glyphicon-search"></span>
+                            <button class="btn btn-default" type="submit">検索</button>
+                        </span>
+                    </div>
                 </div>
-            </div>
+            </form>
             <!-- 新着ランキング -->
             <div class="col-xs-12 ranking-list">
                 <div class="text-center" style="border: 1px solid black">新着</div>

--- a/resources/views/layouts/template.blade.php
+++ b/resources/views/layouts/template.blade.php
@@ -74,8 +74,8 @@
                 <div class="col-xs-3" id="sn-icon" style="padding-left:0px;">
                     <div class="row">
                         <div class="col-xs-4 icon-btn" style="">
-                            <button class="btn btn-ghost" class="siori-bgc"><span class="glyphicon glyphicon-search"></span></button>
-                        </div>  
+                            <button class="btn btn-ghost" class="siori-bgc" onclick="location.href='{{route("search")}}'"><span class="glyphicon glyphicon-search"></span></button>
+                        </div>
                         <div class="col-xs-4 col-xs-offset-1 icon-btn">
                             <button class="btn btn-ghost" class="siori-bgc"><span class="glyphicon glyphicon-bell"></span></button>
                         </div>


### PR DESCRIPTION
・ホームの検索フォームの有効化
・本ページのタグがタグ検索のリンクとして機能するように
・テンプレートにある検索ボタンをとりあえず検索ページのリンクにした
・ホームの新着順の下にある、もっと見るボタンを新着順の検索結果につなげた