### PR TITLE
[fix] profile がない場合のデフォルト値を設定した。

### DIFF
--- a/app/SioriFriends/Models/User/User.php
+++ b/app/SioriFriends/Models/User/User.php
@@ -55,7 +55,13 @@ class User extends Authenticatable
      */
     public function profile()
     {
-        return $this->hasOne(Profile::class);
+        return $this
+            ->hasOne(Profile::class)
+            ->withDefault([
+                'user_id' => $this->id,
+                'intro' => '',
+                'icon_path' => '/img/icons/default.png',
+            ]);
     }
 
     /**


### PR DESCRIPTION
withDefault() でprofileがない場合はデフォルト値を返すようにした。
